### PR TITLE
add Run command to README, when fail to operate go get

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ A Minecraft like game written in go, just for fun!
 
 `cd $GOPATH/src/github.com/icexin/gocraft && gocraft`
 
+or 
+
+`cd $GOPATH/src/github.com/icexin/gocraft && go build`
+
+`./gocraft`
+
 ## How to play
 
 - W, S, A, D to move around.


### PR DESCRIPTION
When I run `go get`, there is no gocraft script. I did run `go build` and `./gocraft` manually. 