### PR TITLE
refactor: extract shaders from Go source and embed them instead

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.13
+    - name: Set up Go 1.16
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.16
       id: go
 
     - name: Check out code into the Go module directory

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ addons:
     - xorg-dev
 language: go
 go:
-  - "1.10"
+  - "1.16"
   - "tip"
 matrix:
   allow_failures:

--- a/block.frag
+++ b/block.frag
@@ -1,0 +1,26 @@
+#version 330 core
+
+in vec2 Tex;
+in float diff;
+in float fog_factor;
+uniform sampler2D tex;
+
+out vec4 FragColor;
+
+const vec3 sky_color = vec3(0.57, 0.71, 0.77);
+
+void main() {
+    vec3 color = vec3(texture(tex, vec2(Tex.x, 1-Tex.y)));
+    if (color == vec3(1,0,1)) {
+        discard;
+    }
+    float df = diff;
+    if (color == vec3(1,1,1)) {
+        df = 1- diff * 0.2;
+    }
+    vec3 ambient = 0.5 * vec3(1, 1, 1);
+    vec3 diffcolor = df * 0.5 * vec3(1,1,1);
+    color = (ambient + diffcolor) * color;
+    color = mix(color, sky_color, fog_factor);
+    FragColor = vec4(color, 1);
+}

--- a/block.vert
+++ b/block.vert
@@ -1,0 +1,24 @@
+#version 330 core
+
+in vec3 pos;
+in vec2 tex;
+in vec3 normal;
+
+uniform mat4 matrix;
+uniform vec3 camera;
+uniform float fogdis;
+
+out vec2 Tex;
+out float diff;
+out float fog_factor;
+
+const vec3 lightdir = normalize(vec3(-1, 1, -1));
+
+void main() {
+    gl_Position = matrix *  vec4(pos, 1.0);
+
+    float camera_distance = distance(pos, camera);
+    fog_factor = pow(clamp(camera_distance/fogdis, 0, 1), 4);
+    Tex = tex;
+    diff = max(0, dot(normal, lightdir));
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/icexin/gocraft
 
-go 1.13
+go 1.16
 
 require (
 	github.com/boltdb/bolt v1.3.1

--- a/line.frag
+++ b/line.frag
@@ -1,0 +1,7 @@
+#version 330 core
+
+out vec4 color;
+
+void main() {
+    color = vec4(0,0,0,1);
+}

--- a/line.vert
+++ b/line.vert
@@ -1,0 +1,9 @@
+#version 330 core
+
+in vec3 pos;
+
+uniform mat4 matrix;
+
+void main() {
+    gl_Position = matrix *  vec4(pos, 1.0);
+}

--- a/player.frag
+++ b/player.frag
@@ -1,0 +1,14 @@
+#version 330 core
+
+in vec2 Tex;
+uniform sampler2D tex;
+
+out vec4 FragColor;
+
+void main() {
+    vec3 color = vec3(texture(tex, vec2(Tex.x, 1-Tex.y)));
+    if (color == vec3(1,0,1)) {
+        discard;
+    }
+    FragColor = vec4(color, 1);
+}

--- a/player.vert
+++ b/player.vert
@@ -1,0 +1,14 @@
+#version 330 core
+
+in vec3 pos;
+in vec2 tex;
+in vec3 normal;
+
+uniform mat4 matrix;
+
+out vec2 Tex;
+
+void main() {
+    gl_Position = matrix *  vec4(pos, 1.0);
+    Tex = tex;
+}

--- a/shader.go
+++ b/shader.go
@@ -1,112 +1,23 @@
 package main
 
+import _ "embed"
+
 var (
-	blockVertexSource = `
-#version 330 core
+	//go:embed block.vert
+	blockVertexSource string
 
-in vec3 pos;
-in vec2 tex;
-in vec3 normal;
+	//go:embed block.frag
+	blockFragmentSource string
 
-uniform mat4 matrix;
-uniform vec3 camera;
-uniform float fogdis;
+	//go:embed line.vert
+	lineVertexSource string
 
-out vec2 Tex;
-out float diff;
-out float fog_factor;
+	//go:embed line.frag
+	lineFragmentSource string
 
-const vec3 lightdir = normalize(vec3(-1, 1, -1));
+	//go:embed player.vert
+	playerVertexSource string
 
-void main() {
-    gl_Position = matrix *  vec4(pos, 1.0);
-
-    float camera_distance = distance(pos, camera);
-    fog_factor = pow(clamp(camera_distance/fogdis, 0, 1), 4);
-    Tex = tex;
-    diff = max(0, dot(normal, lightdir));
-}
-`
-
-	blockFragmentSource = `
-#version 330 core
-
-in vec2 Tex;
-in float diff;
-in float fog_factor;
-uniform sampler2D tex;
-
-out vec4 FragColor;
-
-const vec3 sky_color = vec3(0.57, 0.71, 0.77);
-
-void main() {
-    vec3 color = vec3(texture(tex, vec2(Tex.x, 1-Tex.y)));
-    if (color == vec3(1,0,1)) {
-        discard;
-    }
-    float df = diff;
-    if (color == vec3(1,1,1)) {
-        df = 1- diff * 0.2;
-    }
-    vec3 ambient = 0.5 * vec3(1, 1, 1);
-    vec3 diffcolor = df * 0.5 * vec3(1,1,1);
-    color = (ambient + diffcolor) * color;
-    color = mix(color, sky_color, fog_factor);
-    FragColor = vec4(color, 1);
-}
-`
-	lineVertexSource = `
-#version 330 core
-
-in vec3 pos;
-
-uniform mat4 matrix;
-
-void main() {
-    gl_Position = matrix *  vec4(pos, 1.0);
-}
-`
-
-	lineFragmentSource = `
-#version 330 core
-
-out vec4 color;
-
-void main() {
-    color = vec4(0,0,0,1);
-}
-`
-	playerVertexSource = `
-#version 330 core
-
-in vec3 pos;
-in vec2 tex;
-in vec3 normal;
-
-uniform mat4 matrix;
-
-out vec2 Tex;
-
-void main() {
-    gl_Position = matrix *  vec4(pos, 1.0);
-    Tex = tex;
-}
-`
-	playerFragmentSource = `
-#version 330 core
-
-in vec2 Tex;
-uniform sampler2D tex;
-
-out vec4 FragColor;
-
-void main() {
-    vec3 color = vec3(texture(tex, vec2(Tex.x, 1-Tex.y)));
-    if (color == vec3(1,0,1)) {
-        discard;
-    }
-    FragColor = vec4(color, 1);
-}
-`
+	//go:embed player.frag
+	playerFragmentSource string
 )


### PR DESCRIPTION
Hi,

was showing the project to my kids today and saw we couldn't edit the shaders with all the possibility of an IDE as they were as string in Go code, so I thought we could use go:embed here.